### PR TITLE
Updated Dependencies

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "sklearn-pandas" %}
-{% set version = "2.0.4" %}
+{% set version = "2.1.0" %}
 
 
 package:
@@ -18,13 +18,13 @@ build:
 requirements:
   host:
     - pip
-    - python >=3.6
+    - python >=3.7
   run:
-    - numpy >=1.18.1
-    - pandas >=1.0.5
-    - python >=3.6
-    - scikit-learn >=0.23.0
-    - scipy >=1.4.1
+    - python >=3.7
+    - scikit-learn>=0.23.0
+    - scipy>=1.5.1
+    - pandas>=1.1.4
+    - numpy>=1.18.1
 
 test:
   imports:
@@ -43,3 +43,4 @@ about:
 extra:
   recipe-maintainers:
     - FernandezMathieu
+    - ragrawal


### PR DESCRIPTION
Sklearn_pandas v2.1 requires scipy>= 1.51 instead of scipy>=1.4.1 Also, now the minimum python version required is 3.7

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
